### PR TITLE
[Fix] UICollectionViewCell이 재사용될 때 다른 GIF이미지가 남아있는 현상

### DIFF
--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4712ECEE2B85227B009B6BE9 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4712ECED2B85227B009B6BE9 /* MainTabBarController.swift */; };
 		4712ECF02B852307009B6BE9 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4712ECEF2B852307009B6BE9 /* ColorExtension.swift */; };
 		4712ECF32B852366009B6BE9 /* TrendingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4712ECF22B852366009B6BE9 /* TrendingCollectionViewCell.swift */; };
+		4727267F2BD7752F00B37D2E /* UIImageViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4727267E2BD7752F00B37D2E /* UIImageViewExtension.swift */; };
 		476A85D92B883D660003E6D6 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D32B883D660003E6D6 /* Bundle.swift */; };
 		476A85DA2B883D660003E6D6 /* gifDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D42B883D660003E6D6 /* gifDataModel.swift */; };
 		476A85DB2B883D660003E6D6 /* TrendingAPIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D52B883D660003E6D6 /* TrendingAPIData.swift */; };
@@ -44,6 +45,7 @@
 		4712ECED2B85227B009B6BE9 /* MainTabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		4712ECEF2B852307009B6BE9 /* ColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		4712ECF22B852366009B6BE9 /* TrendingCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingCollectionViewCell.swift; sourceTree = "<group>"; };
+		4727267E2BD7752F00B37D2E /* UIImageViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageViewExtension.swift; sourceTree = "<group>"; };
 		476A85D32B883D660003E6D6 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		476A85D42B883D660003E6D6 /* gifDataModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = gifDataModel.swift; sourceTree = "<group>"; };
 		476A85D52B883D660003E6D6 /* TrendingAPIData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingAPIData.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				4712ECF22B852366009B6BE9 /* TrendingCollectionViewCell.swift */,
+				4727267E2BD7752F00B37D2E /* UIImageViewExtension.swift */,
 			);
 			path = CustomView;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				476A85DB2B883D660003E6D6 /* TrendingAPIData.swift in Sources */,
 				476A85D92B883D660003E6D6 /* Bundle.swift in Sources */,
 				4712ECF32B852366009B6BE9 /* TrendingCollectionViewCell.swift in Sources */,
+				4727267F2BD7752F00B37D2E /* UIImageViewExtension.swift in Sources */,
 				476A85DA2B883D660003E6D6 /* gifDataModel.swift in Sources */,
 				4712ECEE2B85227B009B6BE9 /* MainTabBarController.swift in Sources */,
 				4712ECBC2B8336A3009B6BE9 /* MainViewController.swift in Sources */,

--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -21,12 +21,12 @@
 		476A85DA2B883D660003E6D6 /* gifDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D42B883D660003E6D6 /* gifDataModel.swift */; };
 		476A85DB2B883D660003E6D6 /* TrendingAPIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D52B883D660003E6D6 /* TrendingAPIData.swift */; };
 		476A85DC2B883D660003E6D6 /* TrendingAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D62B883D660003E6D6 /* TrendingAPIManager.swift */; };
-		476A85E82B9865260003E6D6 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 476A85E72B9865250003E6D6 /* APIKey.plist */; };
 		476A85EC2B9C5A260003E6D6 /* BookmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */; };
 		476A86012BA0675E0003E6D6 /* LoadingImage.gif in Resources */ = {isa = PBXBuildFile; fileRef = 476A86002BA0675E0003E6D6 /* LoadingImage.gif */; };
-		476A86112BA1A06A0003E6D6 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE12B84D155009B6BE9 /* SnapKit */; };
-		476A86122BA1A06A0003E6D6 /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE32B84D155009B6BE9 /* SnapKit-Dynamic */; };
 		476A86142BA1A07E0003E6D6 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */; };
+		47EE0C002BAAB7360019C7A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE12B84D155009B6BE9 /* SnapKit */; };
+		47EE0C012BAAB7360019C7A3 /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE32B84D155009B6BE9 /* SnapKit-Dynamic */; };
+		47EE0C032BAAB9E30019C7A3 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47EE0C022BAAB9E30019C7A3 /* APIKey.plist */; };
 		E08FA3042085B2B8C7AE0FA9 /* Pods_GIPHYSearcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */; };
 /* End PBXBuildFile section */
 
@@ -48,10 +48,10 @@
 		476A85D42B883D660003E6D6 /* gifDataModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = gifDataModel.swift; sourceTree = "<group>"; };
 		476A85D52B883D660003E6D6 /* TrendingAPIData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingAPIData.swift; sourceTree = "<group>"; };
 		476A85D62B883D660003E6D6 /* TrendingAPIManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingAPIManager.swift; sourceTree = "<group>"; };
-		476A85E72B9865250003E6D6 /* APIKey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
 		476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkButton.swift; sourceTree = "<group>"; };
 		476A86002BA0675E0003E6D6 /* LoadingImage.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = LoadingImage.gif; path = GIPHYSearcher/Resources/Assets.xcassets/LoadingImage.dataset/LoadingImage.gif; sourceTree = "<group>"; };
 		476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
+		47EE0C022BAAB9E30019C7A3 /* APIKey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
 		A528527BAB12FADB0DFDE62B /* Pods-GIPHYSearcher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GIPHYSearcher.debug.xcconfig"; path = "Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher.debug.xcconfig"; sourceTree = "<group>"; };
 		D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GIPHYSearcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -61,8 +61,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4712ECE22B84D155009B6BE9 /* SnapKit in Frameworks */,
-				4712ECE42B84D155009B6BE9 /* SnapKit-Dynamic in Frameworks */,
+				47EE0C012BAAB7360019C7A3 /* SnapKit-Dynamic in Frameworks */,
+				47EE0C002BAAB7360019C7A3 /* SnapKit in Frameworks */,
 				E08FA3042085B2B8C7AE0FA9 /* Pods_GIPHYSearcher.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -113,7 +113,7 @@
 		4712ECD32B84C0A1009B6BE9 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
-				476A85E72B9865250003E6D6 /* APIKey.plist */,
+				47EE0C022BAAB9E30019C7A3 /* APIKey.plist */,
 				476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */,
 				476A85D32B883D660003E6D6 /* Bundle.swift */,
 				476A85D42B883D660003E6D6 /* gifDataModel.swift */,
@@ -270,8 +270,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				476A85E82B9865260003E6D6 /* APIKey.plist in Resources */,
 				476A86012BA0675E0003E6D6 /* LoadingImage.gif in Resources */,
+				47EE0C032BAAB9E30019C7A3 /* APIKey.plist in Resources */,
 				4712ECC42B8336A4009B6BE9 /* LaunchScreen.storyboard in Resources */,
 				4712ECC12B8336A4009B6BE9 /* Assets.xcassets in Resources */,
 			);

--- a/GIPHYSearcher/Presentation/Bookmark/BookmarkViewController.swift
+++ b/GIPHYSearcher/Presentation/Bookmark/BookmarkViewController.swift
@@ -88,10 +88,10 @@ extension BookmarkViewController: UICollectionViewDelegate, UICollectionViewData
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "BookmarkCollectionViewCell", for: indexPath) as? TrendingCollectionViewCell else {
             return UICollectionViewCell()
         }
-                
-        if let url = URL(string: self.bookmarkedData[indexPath.row].url) {
-            cell.testImageView.startGif(with: .localPath(url))
-        }
+
+        let url = URL(string: self.bookmarkedData[indexPath.row].url)
+        let placeholder = "LoadingImage"
+        cell.imageView.setImage(url: url, placeholder: placeholder)
         
         cell.bookmarkButton.setImage(UIImage(systemName: "bookmark.fill"), for: .normal)
         cell.bookmarkButton.tag = indexPath.row

--- a/GIPHYSearcher/Presentation/Main/CustomView/TrendingCollectionViewCell.swift
+++ b/GIPHYSearcher/Presentation/Main/CustomView/TrendingCollectionViewCell.swift
@@ -11,8 +11,7 @@ import SnapKit
 import JellyGif
 
 class TrendingCollectionViewCell: UICollectionViewCell {
-    let testImageView = JellyGifImageView() 
-    
+    let imageView = UIImageView()
     let bookmarkButton = BookmarkButton()
     
     override init(frame: CGRect) {
@@ -21,7 +20,7 @@ class TrendingCollectionViewCell: UICollectionViewCell {
         setUp()
         layout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -30,15 +29,14 @@ class TrendingCollectionViewCell: UICollectionViewCell {
         self.contentView.backgroundColor = .backgroundColor
         self.contentView.clipsToBounds = true
         self.contentView.layer.cornerRadius = 10
-        
-        self.testImageView.startGif(with: .name("LoadingImage"))
     }
     
     func layout() {
-        self.contentView.addSubview(testImageView)
+        self.contentView.addSubview(imageView)
+        
         self.contentView.addSubview(bookmarkButton)
         
-        testImageView.snp.makeConstraints { make in
+        imageView.snp.makeConstraints { make in
             make.left.right.top.bottom.equalToSuperview()
         }
         

--- a/GIPHYSearcher/Presentation/Main/CustomView/UIImageViewExtension.swift
+++ b/GIPHYSearcher/Presentation/Main/CustomView/UIImageViewExtension.swift
@@ -1,0 +1,39 @@
+//
+//  UIImageViewExtension.swift
+//  GIPHYSearcher
+//
+//  Created by 강민지 on 4/23/24.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+import JellyGif
+
+
+extension UIImageView {
+    func setImage(url: URL?, placeholder: String?) {
+        var gifView = JellyGifImageView()
+        
+        self.addSubview(gifView)
+        gifView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        guard let placeholder else { return }
+        gifView.startGif(with: .name(placeholder))
+        
+        guard let url else { return }
+        
+        if let cachedImage = ImageCacheManager.shared.getCacheImageData(urlString: url.absoluteString) {
+            gifView.startGif(with: .data(cachedImage))
+        } else {
+                guard let data else { return }
+                ImageCacheManager.shared.setCacheImage(imageData: data, urlString: url.absoluteString)
+                if url == view.savedURL {
+                    DispatchQueue.main.async {
+                        gifView.startGif(with: .data(data))
+                    }
+                }
+    }
+}

--- a/GIPHYSearcher/Presentation/Main/MainViewController.swift
+++ b/GIPHYSearcher/Presentation/Main/MainViewController.swift
@@ -128,27 +128,13 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TrendingCollectionViewCell", for: indexPath) as? TrendingCollectionViewCell else {
             return UICollectionViewCell()
         }
-                        
-        guard let imageUrl = URL(string: trendingData[indexPath.row].url) else {
-            cell.testImageView.startGif(with: .name("LoadingImage"))
-            return cell
-        }
-
-        if let cacheImage = ImageCacheManager.shared.getCacheImageData(urlString: imageUrl.absoluteString) {
-            if indexPath == collectionView.indexPath(for: cell) {
-                cell.testImageView.startGif(with: .data(cacheImage))
-            }
-        } else {
-            DispatchQueue.global().async {
-                if let data = try? Data(contentsOf: imageUrl) {
-                    ImageCacheManager.shared.setCacheImage(imageData: data, urlString: imageUrl.absoluteString)
-                    cell.testImageView.startGif(with: .localPath(imageUrl))
-                }
-            }
-        }
         
         let cellId = trendingData[indexPath.row].id
+        let url = URL(string: trendingData[indexPath.row].url)
+        let placeholder = "LoadingImage"
+        cell.imageView.setImage(url: url, placeholder: placeholder)
         
+        let cellId = trendingData[indexPath.row].id
         if self.bookmarkedData.contains(where: { $0.id == cellId }) {
             cell.bookmarkButton.setImage(UIImage(systemName: "bookmark.fill"), for: .normal)
             trendingData[indexPath.row].bookmarkButtonActive = true


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 구현 방식 변경
- [x] 버그 수정
- [ ] 그 외:

## 변경 내용
`cell`이 재사용될 때, 이전에 사용된 `cell`의 gif가 보이지 않고 현재 `cell`의 gif만 보여지도록 수정
- `collectionView`의 `cell`에서 gif가 들어가는 `view` 수정
`JellyImageView` -> `UIImageView` 안에 `JellyImageView` 삽입
-   이미지캐싱에서 이미지를 불러오는 방식 수정
`Data(contentsOf:)` -> `URLSession` 

## 반영 브랜치
fix/#12 -> develop
- #12 

## 스크린샷
수정 전
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/3059244a-89f2-48b3-b5c5-10b6de17d5df" width="200"/>

수정 후
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/c956353b-c9e5-423c-b295-1ab6b598a366" width="200"/>
