### PR TITLE
[Fix] GIF를 클릭하면 GIF가 사라지는 현상

### DIFF
--- a/GIPHYSearcher/Presentation/Main/MainViewController.swift
+++ b/GIPHYSearcher/Presentation/Main/MainViewController.swift
@@ -205,4 +205,15 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
         return cell
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let cell = collectionView.cellForItem(at: indexPath) as? GifCollectionViewCell {
+            cell.imageView.startAnimating()
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        if let cell = collectionView.cellForItem(at: indexPath) as? GifCollectionViewCell {
+            cell.imageView.startAnimating()
+        }
+    }
 }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 구현 방식 변경
- [x] 버그 수정
- [ ] 그 외:

## 변경 내용
`UICollectionViewCell` 내의 GIF를 클릭할 때 GIF가 사라지지 않도록 변경
- `UICollectionViewDelegate`에서 `didSelectItemAt`, `didDeselectItemAt` 메소드 추가
-  메소드 내에 `animationImages`를 다시 재생시켜주는 코드 추가

## 반영 브랜치
fix/#19 -> develop
- #19 

## 스크린샷
수정 전
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/47318f40-505e-4229-8ba2-9d005a1c5b68" width="200"/>

수정 후
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/0bb96c46-020c-4fde-95e4-0092967221b7" width="200"/>