### PR TITLE
[Feature/#23] Setting - 테이블뷰 섹션 구현

### DIFF
--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		476A85EC2B9C5A260003E6D6 /* BookmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */; };
 		476A86012BA0675E0003E6D6 /* LoadingImage.gif in Resources */ = {isa = PBXBuildFile; fileRef = 476A86002BA0675E0003E6D6 /* LoadingImage.gif */; };
 		476A86142BA1A07E0003E6D6 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */; };
+		479DAF082BFF26A0004DA33B /* DeveloperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF072BFF26A0004DA33B /* DeveloperViewController.swift */; };
 		479DAF0A2BFF26B4004DA33B /* DeveloperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF092BFF26B4004DA33B /* DeveloperCell.swift */; };
 		479DAF0C2BFF26BC004DA33B /* DeveloperSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */; };
 		47EE0C002BAAB7360019C7A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE12B84D155009B6BE9 /* SnapKit */; };
@@ -64,6 +65,7 @@
 		476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkButton.swift; sourceTree = "<group>"; };
 		476A86002BA0675E0003E6D6 /* LoadingImage.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = LoadingImage.gif; path = GIPHYSearcher/Resources/Assets.xcassets/LoadingImage.dataset/LoadingImage.gif; sourceTree = "<group>"; };
 		476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
+		479DAF072BFF26A0004DA33B /* DeveloperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperViewController.swift; sourceTree = "<group>"; };
 		479DAF092BFF26B4004DA33B /* DeveloperCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperCell.swift; sourceTree = "<group>"; };
 		479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSection.swift; sourceTree = "<group>"; };
 		47EE0C022BAAB9E30019C7A3 /* APIKey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				476A85DA2B883D660003E6D6 /* gifDataModel.swift in Sources */,
 				479DAF0C2BFF26BC004DA33B /* DeveloperSection.swift in Sources */,
 				4712ECEE2B85227B009B6BE9 /* MainTabBarController.swift in Sources */,
+				479DAF082BFF26A0004DA33B /* DeveloperViewController.swift in Sources */,
 				4712ECBC2B8336A3009B6BE9 /* MainViewController.swift in Sources */,
 				476A86142BA1A07E0003E6D6 /* ImageCacheManager.swift in Sources */,
 				4712ECB82B8336A3009B6BE9 /* AppDelegate.swift in Sources */,

--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		476A85EC2B9C5A260003E6D6 /* BookmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */; };
 		476A86012BA0675E0003E6D6 /* LoadingImage.gif in Resources */ = {isa = PBXBuildFile; fileRef = 476A86002BA0675E0003E6D6 /* LoadingImage.gif */; };
 		476A86142BA1A07E0003E6D6 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */; };
+		479DAF0A2BFF26B4004DA33B /* DeveloperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF092BFF26B4004DA33B /* DeveloperCell.swift */; };
 		47EE0C002BAAB7360019C7A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE12B84D155009B6BE9 /* SnapKit */; };
 		47EE0C032BAAB9E30019C7A3 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47EE0C022BAAB9E30019C7A3 /* APIKey.plist */; };
 		E08FA3042085B2B8C7AE0FA9 /* Pods_GIPHYSearcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */; };
@@ -62,6 +63,7 @@
 		476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkButton.swift; sourceTree = "<group>"; };
 		476A86002BA0675E0003E6D6 /* LoadingImage.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = LoadingImage.gif; path = GIPHYSearcher/Resources/Assets.xcassets/LoadingImage.dataset/LoadingImage.gif; sourceTree = "<group>"; };
 		476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
+		479DAF092BFF26B4004DA33B /* DeveloperCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperCell.swift; sourceTree = "<group>"; };
 		47EE0C022BAAB9E30019C7A3 /* APIKey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
 		A528527BAB12FADB0DFDE62B /* Pods-GIPHYSearcher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GIPHYSearcher.debug.xcconfig"; path = "Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher.debug.xcconfig"; sourceTree = "<group>"; };
 		D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GIPHYSearcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -193,6 +195,7 @@
 		4712ECE82B85224C009B6BE9 /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				479DAF052BFF2638004DA33B /* Developer */,
 				475E825F2BFE42450071BF14 /* CustomView */,
 				4712ECEB2B85226D009B6BE9 /* SettingViewController.swift */,
 			);
@@ -225,6 +228,23 @@
 				475E82642BFE42690071BF14 /* SettingInfoCell.swift */,
 			);
 			path = "Custom Cell";
+			sourceTree = "<group>";
+		};
+		479DAF052BFF2638004DA33B /* Developer */ = {
+			isa = PBXGroup;
+			children = (
+				479DAF062BFF2644004DA33B /* CustomView */,
+				479DAF072BFF26A0004DA33B /* DeveloperViewController.swift */,
+			);
+			path = Developer;
+			sourceTree = "<group>";
+		};
+		479DAF062BFF2644004DA33B /* CustomView */ = {
+			isa = PBXGroup;
+			children = (
+				479DAF092BFF26B4004DA33B /* DeveloperCell.swift */,
+			);
+			path = CustomView;
 			sourceTree = "<group>";
 		};
 		7E538E1A59A5A6DC04858E17 /* Frameworks */ = {
@@ -375,6 +395,7 @@
 				475E82672BFE44390071BF14 /* SettingSection.swift in Sources */,
 				476A85EC2B9C5A260003E6D6 /* BookmarkButton.swift in Sources */,
 				476A85DC2B883D660003E6D6 /* GiphyAPIManager.swift in Sources */,
+				479DAF0A2BFF26B4004DA33B /* DeveloperCell.swift in Sources */,
 				4712ECBA2B8336A3009B6BE9 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		476A86012BA0675E0003E6D6 /* LoadingImage.gif in Resources */ = {isa = PBXBuildFile; fileRef = 476A86002BA0675E0003E6D6 /* LoadingImage.gif */; };
 		476A86142BA1A07E0003E6D6 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */; };
 		479DAF0A2BFF26B4004DA33B /* DeveloperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF092BFF26B4004DA33B /* DeveloperCell.swift */; };
+		479DAF0C2BFF26BC004DA33B /* DeveloperSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */; };
 		47EE0C002BAAB7360019C7A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE12B84D155009B6BE9 /* SnapKit */; };
 		47EE0C032BAAB9E30019C7A3 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47EE0C022BAAB9E30019C7A3 /* APIKey.plist */; };
 		E08FA3042085B2B8C7AE0FA9 /* Pods_GIPHYSearcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */; };
@@ -64,6 +65,7 @@
 		476A86002BA0675E0003E6D6 /* LoadingImage.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = LoadingImage.gif; path = GIPHYSearcher/Resources/Assets.xcassets/LoadingImage.dataset/LoadingImage.gif; sourceTree = "<group>"; };
 		476A86132BA1A07E0003E6D6 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		479DAF092BFF26B4004DA33B /* DeveloperCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperCell.swift; sourceTree = "<group>"; };
+		479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSection.swift; sourceTree = "<group>"; };
 		47EE0C022BAAB9E30019C7A3 /* APIKey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
 		A528527BAB12FADB0DFDE62B /* Pods-GIPHYSearcher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GIPHYSearcher.debug.xcconfig"; path = "Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher.debug.xcconfig"; sourceTree = "<group>"; };
 		D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GIPHYSearcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -243,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				479DAF092BFF26B4004DA33B /* DeveloperCell.swift */,
+				479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */,
 			);
 			path = CustomView;
 			sourceTree = "<group>";
@@ -387,6 +390,7 @@
 				475E82762BFE5C6C0071BF14 /* SettingSectionFooterView.swift in Sources */,
 				4727267F2BD7752F00B37D2E /* UIImageViewExtension.swift in Sources */,
 				476A85DA2B883D660003E6D6 /* gifDataModel.swift in Sources */,
+				479DAF0C2BFF26BC004DA33B /* DeveloperSection.swift in Sources */,
 				4712ECEE2B85227B009B6BE9 /* MainTabBarController.swift in Sources */,
 				4712ECBC2B8336A3009B6BE9 /* MainViewController.swift in Sources */,
 				476A86142BA1A07E0003E6D6 /* ImageCacheManager.swift in Sources */,

--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		475E82612BFE42570071BF14 /* SettingDisclosureCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E82602BFE42570071BF14 /* SettingDisclosureCell.swift */; };
 		475E82652BFE42690071BF14 /* SettingInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E82642BFE42690071BF14 /* SettingInfoCell.swift */; };
 		475E82672BFE44390071BF14 /* SettingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E82662BFE44390071BF14 /* SettingSection.swift */; };
+		475E826D2BFE528C0071BF14 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E826C2BFE528C0071BF14 /* Constants.swift */; };
 		475E82732BFE5C200071BF14 /* SettingSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E82722BFE5C200071BF14 /* SettingSectionHeaderView.swift */; };
 		475E82762BFE5C6C0071BF14 /* SettingSectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E82752BFE5C6C0071BF14 /* SettingSectionFooterView.swift */; };
 		476A85D92B883D660003E6D6 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A85D32B883D660003E6D6 /* Bundle.swift */; };
@@ -56,6 +57,7 @@
 		475E82602BFE42570071BF14 /* SettingDisclosureCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDisclosureCell.swift; sourceTree = "<group>"; };
 		475E82642BFE42690071BF14 /* SettingInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingInfoCell.swift; sourceTree = "<group>"; };
 		475E82662BFE44390071BF14 /* SettingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSection.swift; sourceTree = "<group>"; };
+		475E826C2BFE528C0071BF14 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		475E82722BFE5C200071BF14 /* SettingSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionHeaderView.swift; sourceTree = "<group>"; };
 		475E82752BFE5C6C0071BF14 /* SettingSectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionFooterView.swift; sourceTree = "<group>"; };
 		476A85D32B883D660003E6D6 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				4727267E2BD7752F00B37D2E /* UIImageViewExtension.swift */,
 				4712ECED2B85227B009B6BE9 /* MainTabBarController.swift */,
 				476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */,
+				475E826C2BFE528C0071BF14 /* Constants.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4712ECEC2B85226D009B6BE9 /* SettingViewController.swift in Sources */,
+				475E826D2BFE528C0071BF14 /* Constants.swift in Sources */,
 				475E82612BFE42570071BF14 /* SettingDisclosureCell.swift in Sources */,
 				475E82652BFE42690071BF14 /* SettingInfoCell.swift in Sources */,
 				4712ECEA2B852264009B6BE9 /* BookmarkViewController.swift in Sources */,

--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		475E826C2BFE528C0071BF14 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		475E82722BFE5C200071BF14 /* SettingSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionHeaderView.swift; sourceTree = "<group>"; };
 		475E82752BFE5C6C0071BF14 /* SettingSectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionFooterView.swift; sourceTree = "<group>"; };
+		475E82792BFF01E10071BF14 /* github.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = github.png; sourceTree = "<group>"; };
+		475E827A2BFF01E10071BF14 /* github@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "github@2x.png"; sourceTree = "<group>"; };
+		475E827B2BFF01E10071BF14 /* github@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "github@3x.png"; sourceTree = "<group>"; };
+		475E827C2BFF01E10071BF14 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Contents.json; sourceTree = "<group>"; };
 		476A85D32B883D660003E6D6 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		476A85D42B883D660003E6D6 /* gifDataModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = gifDataModel.swift; sourceTree = "<group>"; };
 		476A85D52B883D660003E6D6 /* TrendingAPIData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendingAPIData.swift; sourceTree = "<group>"; };
@@ -237,6 +241,18 @@
 			path = "Custom Cell";
 			sourceTree = "<group>";
 		};
+		475E82782BFF01E10071BF14 /* github.imageset */ = {
+			isa = PBXGroup;
+			children = (
+				475E82792BFF01E10071BF14 /* github.png */,
+				475E827A2BFF01E10071BF14 /* github@2x.png */,
+				475E827B2BFF01E10071BF14 /* github@3x.png */,
+				475E827C2BFF01E10071BF14 /* Contents.json */,
+			);
+			name = github.imageset;
+			path = GIPHYSearcher/Resources/Assets.xcassets/Icon/github.imageset;
+			sourceTree = "<group>";
+		};
 		479DAF052BFF2638004DA33B /* Developer */ = {
 			isa = PBXGroup;
 			children = (
@@ -258,6 +274,7 @@
 		7E538E1A59A5A6DC04858E17 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				475E82782BFF01E10071BF14 /* github.imageset */,
 				D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */,
 			);
 			name = Frameworks;
@@ -274,6 +291,7 @@
 				4712ECB02B8336A3009B6BE9 /* Sources */,
 				4712ECB12B8336A3009B6BE9 /* Frameworks */,
 				4712ECB22B8336A3009B6BE9 /* Resources */,
+				8BA109C111A836FB8F6E3ACA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);

--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -310,6 +310,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		8BA109C111A836FB8F6E3ACA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		C618D48C2452A30C65E822C3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/GIPHYSearcher/Presentation/Common/Constants.swift
+++ b/GIPHYSearcher/Presentation/Common/Constants.swift
@@ -1,0 +1,14 @@
+//
+//  Constants.swift
+//  GIPHYSearcher
+//
+//  Created by 강민지 on 5/23/24.
+//
+
+import Foundation
+import UIKit
+
+struct Developer {
+    static let name = "Minji Kang"
+    static let description = "github.com/aldalddl"
+}

--- a/GIPHYSearcher/Presentation/Common/Constants.swift
+++ b/GIPHYSearcher/Presentation/Common/Constants.swift
@@ -12,3 +12,10 @@ struct Developer {
     static let name = "Minji Kang"
     static let description = "github.com/aldalddl"
 }
+
+struct App {
+    static let currentVersion: String = {
+        guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return "Undefined" }
+        return version
+    }()
+}

--- a/GIPHYSearcher/Presentation/Common/UIImageViewExtension.swift
+++ b/GIPHYSearcher/Presentation/Common/UIImageViewExtension.swift
@@ -72,4 +72,16 @@ extension UIImageView {
         self.animationRepeatCount = 0
         self.startAnimating()
     }
+    
+    func resizeImage(imageName: String, newSize: CGSize) {
+        UIGraphicsBeginImageContextWithOptions(newSize, false, UIScreen.main.scale)
+        
+        self.image = UIImage(named: imageName)
+        self.image?.draw(in: CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height))
+        
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        self.image = newImage
+    }
 }

--- a/GIPHYSearcher/Presentation/Setting/Developer/CustomView/DeveloperCell.swift
+++ b/GIPHYSearcher/Presentation/Setting/Developer/CustomView/DeveloperCell.swift
@@ -1,0 +1,26 @@
+//
+//  DeveloperCell.swift
+//  GIPHYSearcher
+//
+//  Created by 강민지 on 5/23/24.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+
+class DeveloperCell: UITableViewCell {
+    static let id = "DeveloperInfoCell"
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+        
+        self.contentView.backgroundColor = .background
+        
+        self.detailTextLabel?.textColor = .gray
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/GIPHYSearcher/Presentation/Setting/Developer/CustomView/DeveloperSection.swift
+++ b/GIPHYSearcher/Presentation/Setting/Developer/CustomView/DeveloperSection.swift
@@ -1,0 +1,48 @@
+//
+//  DeveloperSection.swift
+//  GIPHYSearcher
+//
+//  Created by 강민지 on 5/23/24.
+//
+
+import Foundation
+
+enum DeveloperSection: Int, CaseIterable {
+    case github, email
+    
+    var icon: String {
+        switch self {
+        case .github:
+            return "github"
+        case .email:
+            return "email"
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .github:
+            return "GitHub"
+        case .email:
+            return "Email"
+        }
+    }
+    
+    var desctiprion: String {
+        switch self {
+        case .github:
+            return "Check out GitHub for more information"
+        case .email:
+            return "Any questions about the app, please let me know"
+        }
+    }
+    
+    var source: String {
+        switch self {
+        case .github:
+            return "https://github.com/aldalddl"
+        case .email:
+            return "aldalddl2007@gmail.com"
+        }
+    }
+}

--- a/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
+++ b/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
@@ -41,6 +41,9 @@ class DeveloperViewController: UIViewController {
     func setUp() {
         self.view.backgroundColor = .background
         
+        self.titleLabel.text = Developer.name
+        self.descriptionLabel.text = Developer.description
+        
         tableView.dataSource = self
         tableView.delegate = self
     }

--- a/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
+++ b/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
@@ -83,6 +83,7 @@ extension DeveloperViewController: UITableViewDataSource, UITableViewDelegate {
         
         cell.textLabel?.text = row.title
         cell.detailTextLabel?.text = row.desctiprion
+        cell.imageView?.resizeImage(imageName: row.icon, newSize: CGSize(width: 30, height: 30))
 
         return cell
     }

--- a/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
+++ b/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
@@ -1,0 +1,99 @@
+//
+//  DeveloperViewController.swift
+//  GIPHYSearcher
+//
+//  Created by 강민지 on 5/23/24.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+
+class DeveloperViewController: UIViewController {
+    var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 35, weight: .regular)
+        return label
+    }()
+    
+    var descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        return label
+    }()
+    
+    var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.backgroundColor = .background
+        tableView.separatorStyle = .none
+        tableView.isScrollEnabled = false
+        tableView.register(DeveloperCell.self, forCellReuseIdentifier: DeveloperCell.id)
+        return tableView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUp()
+        layout()
+    }
+    
+    func setUp() {
+        self.view.backgroundColor = .background
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+    
+    func layout() {
+        self.view.addSubview(titleLabel)
+        self.view.addSubview(descriptionLabel)
+        self.view.addSubview(tableView)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            make.centerX.equalToSuperview()
+        }
+        
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(5)
+            make.centerX.equalToSuperview()
+        }
+        
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(descriptionLabel.snp.bottom).offset(35)
+            make.left.right.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(20)
+        }
+    }
+}
+
+extension DeveloperViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return DeveloperSection.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: DeveloperCell.id, for: indexPath) as? DeveloperCell else { return UITableViewCell() }
+        
+        guard let row = DeveloperSection(rawValue: indexPath.row) else { return UITableViewCell() }
+        
+        cell.textLabel?.text = row.title
+        cell.detailTextLabel?.text = row.desctiprion
+
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let row = DeveloperSection(rawValue: indexPath.row) else { return }
+        
+        switch row {
+        case .github:
+            if let url = URL(string: row.source) {
+                UIApplication.shared.open(url)
+            }
+        case .email:
+            UIPasteboard.general.string = row.source
+        }
+    }
+}

--- a/GIPHYSearcher/Presentation/Setting/SettingViewController.swift
+++ b/GIPHYSearcher/Presentation/Setting/SettingViewController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import SnapKit
+import MaterialComponents.MaterialBottomSheet
 
 class SettingViewController: UIViewController {
     let settingTableView: UITableView = {
@@ -46,6 +47,17 @@ class SettingViewController: UIViewController {
     }
 }
 
+// MARK: Functions
+extension SettingViewController {
+    func openBottomSheet() {
+        let contentViewController = DeveloperViewController()
+        let bottomSheet = MDCBottomSheetController(contentViewController: contentViewController)
+        
+        bottomSheet.preferredContentSize = CGSize(width: self.view.frame.size.width, height: 300)
+        present(bottomSheet, animated: true, completion: nil)
+    }
+}
+
 // MARK: UITableView DataSource
 extension SettingViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -80,6 +92,17 @@ extension SettingViewController: UITableViewDataSource {
                 cell.textLabel?.text = row.desctiprion
                 cell.imageView?.image = UIImage(systemName: row.icon)
                 return cell
+            }
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let section = SettingSection(rawValue: indexPath.section) else { return }
+        
+        switch section {
+        case .information:
+            if Information(rawValue: indexPath.row) == .developer {
+                openBottomSheet()
             }
         }
     }

--- a/GIPHYSearcher/Presentation/Setting/SettingViewController.swift
+++ b/GIPHYSearcher/Presentation/Setting/SettingViewController.swift
@@ -72,6 +72,7 @@ extension SettingViewController: UITableViewDataSource {
             case .version:
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingInfoCell.id, for: indexPath) as? SettingInfoCell else { return UITableViewCell() }
                 cell.textLabel?.text = row.desctiprion
+                cell.subLabel.text = App.currentVersion
                 cell.imageView?.image = UIImage(systemName: row.icon)
                 return cell
             case .developer:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,3 +1,44 @@
-PODFILE CHECKSUM: 2901e7162da215b01491aea2b20e38e416d2839d
+PODS:
+  - MaterialComponents/Availability (124.2.0)
+  - MaterialComponents/BottomSheet (124.2.0):
+    - MaterialComponents/Elevation
+    - MaterialComponents/private/KeyboardWatcher
+    - MaterialComponents/private/Math
+    - MaterialComponents/ShadowElevations
+    - MaterialComponents/ShadowLayer
+    - MaterialComponents/ShapeLibrary
+    - MaterialComponents/Shapes
+  - MaterialComponents/Elevation (124.2.0):
+    - MaterialComponents/Availability
+    - MaterialComponents/private/Color
+    - MaterialComponents/private/Math
+  - MaterialComponents/private/Application (124.2.0)
+  - MaterialComponents/private/Color (124.2.0):
+    - MaterialComponents/Availability
+  - MaterialComponents/private/KeyboardWatcher (124.2.0):
+    - MaterialComponents/private/Application
+  - MaterialComponents/private/Math (124.2.0)
+  - MaterialComponents/ShadowElevations (124.2.0)
+  - MaterialComponents/ShadowLayer (124.2.0):
+    - MaterialComponents/ShadowElevations
+  - MaterialComponents/ShapeLibrary (124.2.0):
+    - MaterialComponents/private/Math
+    - MaterialComponents/Shapes
+  - MaterialComponents/Shapes (124.2.0):
+    - MaterialComponents/private/Color
+    - MaterialComponents/private/Math
+    - MaterialComponents/ShadowLayer
+
+DEPENDENCIES:
+  - MaterialComponents/BottomSheet
+
+SPEC REPOS:
+  trunk:
+    - MaterialComponents
+
+SPEC CHECKSUMS:
+  MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
+
+PODFILE CHECKSUM: 40e5227a5241291876bb84864b893dcf7a2e4d66
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 구현 방식 변경
- [ ] 버그 수정
- [ ] 그 외:

## 변경 내용
- 설정화면의 `Info` 섹션 구현
   - `App Version`: 앱의 릴리즈 버전 표시 (`CFBundleShortVersionString`)
   - `Developer Info`: 하단 팝업 뷰 (외부 라이브러리 `MaterialComponents` - `BottomSheet`)
       - 깃허브 (브라우저로 열림)
       - 이메일 (클립보드에 복사)

## 반영 브랜치
ex) feature/#23 -> develop
- #23 
 
</br>

## 스크린샷

<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/87f8e036-77ea-4fa3-9430-244fcb1f1488" width="200"/>

<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/b7b49525-92cb-445c-b6a6-661c28706ae5" width="200"/>