### PR TITLE
[Feature/#18] Main - GIF를 클릭할 때 검색어 복사되기 

### DIFF
--- a/GIPHYSearcher.xcodeproj/project.pbxproj
+++ b/GIPHYSearcher.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		479DAF082BFF26A0004DA33B /* DeveloperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF072BFF26A0004DA33B /* DeveloperViewController.swift */; };
 		479DAF0A2BFF26B4004DA33B /* DeveloperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF092BFF26B4004DA33B /* DeveloperCell.swift */; };
 		479DAF0C2BFF26BC004DA33B /* DeveloperSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */; };
+		479DAF0E2BFF2FDF004DA33B /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DAF0D2BFF2FDF004DA33B /* BaseViewController.swift */; };
 		47EE0C002BAAB7360019C7A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4712ECE12B84D155009B6BE9 /* SnapKit */; };
 		47EE0C032BAAB9E30019C7A3 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 47EE0C022BAAB9E30019C7A3 /* APIKey.plist */; };
 		E08FA3042085B2B8C7AE0FA9 /* Pods_GIPHYSearcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */; };
@@ -74,6 +75,7 @@
 		479DAF072BFF26A0004DA33B /* DeveloperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperViewController.swift; sourceTree = "<group>"; };
 		479DAF092BFF26B4004DA33B /* DeveloperCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperCell.swift; sourceTree = "<group>"; };
 		479DAF0B2BFF26BC004DA33B /* DeveloperSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSection.swift; sourceTree = "<group>"; };
+		479DAF0D2BFF2FDF004DA33B /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		47EE0C022BAAB9E30019C7A3 /* APIKey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKey.plist; sourceTree = "<group>"; };
 		A528527BAB12FADB0DFDE62B /* Pods-GIPHYSearcher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GIPHYSearcher.debug.xcconfig"; path = "Target Support Files/Pods-GIPHYSearcher/Pods-GIPHYSearcher.debug.xcconfig"; sourceTree = "<group>"; };
 		D8F7A1B2673660EDE6EDC4CE /* Pods_GIPHYSearcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GIPHYSearcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -191,6 +193,7 @@
 				4712ECED2B85227B009B6BE9 /* MainTabBarController.swift */,
 				476A85EB2B9C5A260003E6D6 /* BookmarkButton.swift */,
 				475E826C2BFE528C0071BF14 /* Constants.swift */,
+				479DAF0D2BFF2FDF004DA33B /* BaseViewController.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -422,6 +425,7 @@
 				4712ECB82B8336A3009B6BE9 /* AppDelegate.swift in Sources */,
 				4712ECF02B852307009B6BE9 /* ColorExtension.swift in Sources */,
 				475E82672BFE44390071BF14 /* SettingSection.swift in Sources */,
+				479DAF0E2BFF2FDF004DA33B /* BaseViewController.swift in Sources */,
 				476A85EC2B9C5A260003E6D6 /* BookmarkButton.swift in Sources */,
 				476A85DC2B883D660003E6D6 /* GiphyAPIManager.swift in Sources */,
 				479DAF0A2BFF26B4004DA33B /* DeveloperCell.swift in Sources */,

--- a/GIPHYSearcher/Presentation/Bookmark/BookmarkViewController.swift
+++ b/GIPHYSearcher/Presentation/Bookmark/BookmarkViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 import SnapKit
 
-class BookmarkViewController: UIViewController {
+class BookmarkViewController: BaseViewController {
     var bookmarkedData = [gifDataModel]()
 
     let bookmarkCollectionView: UICollectionView = {
@@ -100,4 +100,23 @@ extension BookmarkViewController: UICollectionViewDelegate, UICollectionViewData
         return cell
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let cell = collectionView.cellForItem(at: indexPath) as? GifCollectionViewCell {
+            cell.imageView.startAnimating()
+        }
+        
+        let gifTitle = gifData[indexPath.row].title
+        let gifSearchWord = gifTitle.replacingOccurrences(of: " GIF", with: "")
+        let navigationViewController = tabBarController?.viewControllers![1] as! UINavigationController
+
+        UIPasteboard.general.string = gifSearchWord
+        guard let tapBarHeight = tabBarController?.tabBar.frame.size.height else { return }
+        showToast(message: "복사 되었습니다", offset: tapBarHeight + 45)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        if let cell = collectionView.cellForItem(at: indexPath) as? GifCollectionViewCell {
+            cell.imageView.startAnimating()
+        }
+    }
 }

--- a/GIPHYSearcher/Presentation/Common/BaseViewController.swift
+++ b/GIPHYSearcher/Presentation/Common/BaseViewController.swift
@@ -14,7 +14,7 @@ class BaseViewController: UIViewController {
         
         let toastLabel = UILabel(frame: labelSize)
         
-        toastLabel.backgroundColor = .white.withAlphaComponent(0.7)
+        toastLabel.backgroundColor = .white.withAlphaComponent(0.8)
         toastLabel.alpha = 1.0
         toastLabel.layer.cornerRadius = 10
         toastLabel.clipsToBounds = true

--- a/GIPHYSearcher/Presentation/Common/BaseViewController.swift
+++ b/GIPHYSearcher/Presentation/Common/BaseViewController.swift
@@ -1,0 +1,53 @@
+//
+//  BaseViewController.swift
+//  GIPHYSearcher
+//
+//  Created by 강민지 on 5/4/24.
+//
+
+import Foundation
+import UIKit
+
+class BaseViewController: UIViewController {
+    func showToast(message: String, offset: CGFloat) {
+        let labelSize = calculateLabelSize(text: message, offset: offset)
+        
+        let toastLabel = UILabel(frame: labelSize)
+        
+        toastLabel.backgroundColor = .white.withAlphaComponent(0.7)
+        toastLabel.alpha = 1.0
+        toastLabel.layer.cornerRadius = 10
+        toastLabel.clipsToBounds = true
+        
+        toastLabel.text = message
+        toastLabel.textColor = .black
+        toastLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        toastLabel.textAlignment = .center
+        toastLabel.adjustsFontSizeToFitWidth = true
+                
+        self.view.addSubview(toastLabel)
+        
+        UIView.animate(withDuration: 1.7, delay: 0.3, options: .curveEaseInOut, animations: {
+            toastLabel.alpha = 0.0
+        }, completion: { (_) in
+            toastLabel.removeFromSuperview()
+        })
+    }
+    
+    func calculateLabelSize(text: String, offset: CGFloat) -> CGRect {
+        let label = UILabel()
+        
+        label.text = text
+        
+        let labelWidth = Int(label.intrinsicContentSize.width) + 10
+        let labelHeight = Int(label.intrinsicContentSize.height) + 10
+        
+        let centerX = (Int(self.view.bounds.width) - labelWidth) / 2
+        let positionY = Int(self.view.frame.size.height) - Int(offset)
+        
+        let labelSize = CGRect(x: centerX, y: positionY, width: labelWidth, height: labelHeight)
+        
+        return labelSize
+    }
+}
+

--- a/GIPHYSearcher/Presentation/Common/BaseViewController.swift
+++ b/GIPHYSearcher/Presentation/Common/BaseViewController.swift
@@ -43,7 +43,7 @@ class BaseViewController: UIViewController {
         let labelHeight = Int(label.intrinsicContentSize.height) + 10
         
         let centerX = (Int(self.view.bounds.width) - labelWidth) / 2
-        let positionY = Int(self.view.frame.size.height) - Int(offset)
+        let positionY = Int(self.view.bounds.maxY) - Int(offset)
         
         let labelSize = CGRect(x: centerX, y: positionY, width: labelWidth, height: labelHeight)
         

--- a/GIPHYSearcher/Presentation/Main/MainViewController.swift
+++ b/GIPHYSearcher/Presentation/Main/MainViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class MainViewController: UIViewController {
+class MainViewController: BaseViewController {
     var gifAPIManager = GiphyAPIManager()
     var bookmarkedData = [gifDataModel]()
     var searchData = [gifDataModel]()
@@ -209,6 +209,13 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
         if let cell = collectionView.cellForItem(at: indexPath) as? GifCollectionViewCell {
             cell.imageView.startAnimating()
         }
+        
+        let gifTitle = gifData[indexPath.row].title
+        let gifSearchWord = gifTitle.replacingOccurrences(of: " GIF", with: "")
+        
+        UIPasteboard.general.string = gifSearchWord
+        guard let tapBarHeight = tabBarController?.tabBar.frame.size.height else { return }
+        showToast(message: "복사 되었습니다", offset: tapBarHeight + 45)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {

--- a/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
+++ b/GIPHYSearcher/Presentation/Setting/Developer/DeveloperViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 import SnapKit
 
-class DeveloperViewController: UIViewController {
+class DeveloperViewController: BaseViewController {
     var titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 35, weight: .regular)
@@ -98,6 +98,7 @@ extension DeveloperViewController: UITableViewDataSource, UITableViewDelegate {
             }
         case .email:
             UIPasteboard.general.string = row.source
+            showToast(message: "이메일 주소가 복사 되었습니다", offset: 75)
         }
     }
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 구현 방식 변경
- [ ] 버그 수정
- [ ] 그 외:

## 변경 내용
- GIF을 클릭할 때, 해당 GIF를 검색할 수 있는 검색어가 클립보드에 복사됨
   - GIF 데이터 중 `title`을 검색이 가능한 `GIF명 by제작자명` 형식으로 변형
   - `UICollectionViewDelegate`의 `didSelectItemAt`메소드에서 `UIPasteboard`를 사용하여 클립보드에 데이터를 입력
   - 복사되었음을 알리는 토스트 메세지 팝업
- 설정 화면에서 메일 주소를 `cell`을 클릭할 때도 토스트 메세지를 띄우도록 추가함

## 반영 브랜치
ex) feature/#18 -> develop
- #18
 
</br>

## 스크린샷

<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/9886b14b-3060-4a75-beb2-986569ad1b52" width="200"/>
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/0ae7f474-d088-4851-9aa6-76ef16fa1a55" width="200"/>
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/3c24f2ae-943d-4f6d-9567-3ee4a79bce60" width="200"/>