### PR TITLE
[Fix] GIF의 북마크가 삭제되지 않는 현상

### DIFF
--- a/GIPHYSearcher/Presentation/Main/MainViewController.swift
+++ b/GIPHYSearcher/Presentation/Main/MainViewController.swift
@@ -49,6 +49,12 @@ class MainViewController: BaseViewController {
         gifCollectionView.reloadData()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        if let encoded = try? JSONEncoder().encode(self.bookmarkedData) {
+            UserDefaults.standard.set(encoded, forKey: "bookmarkedData")
+        }
+    }
+    
     // MARK: SetUp
     func setUp() {
         self.view.backgroundColor = .backgroundColor
@@ -102,21 +108,24 @@ extension MainViewController {
         
         if !buttonActive {
             sender.setImage(UIImage(systemName: "bookmark.fill"), for: .normal)
+            
             self.bookmarkedData.append(gifData[sender.tag])
+            
+            gifData[sender.tag].bookmarkButtonActive = true
         } else {
             sender.setImage(UIImage(systemName: "bookmark"), for: .normal)
             
             if let filteredIndex = gifData.firstIndex(where: { $0.id == sender.customTag }) {
                 self.bookmarkedData.remove(at: filteredIndex)
             }
+            
+            gifData[sender.tag].bookmarkButtonActive = false
         }
-    
+            
         if let encoded = try? JSONEncoder().encode(self.bookmarkedData) {
             UserDefaults.standard.set(encoded, forKey: "bookmarkedData")
         }
         
-        buttonActive = !buttonActive
-
         bookmarkViewController.bookmarkCollectionView.reloadData()
     }
 }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 구현 방식 변경
- [x] 버그 수정
- [ ] 그 외:

## 변경 내용
북마크 되어있는 GIF의 북마크 버튼을 클릭 시
- 북마크 버튼의 이미지가 `채워진 이미지로 유지됨` 
-> `비어있는 이미지로 변경됨`
- 북마크 화면에 해당 GIF가 `중복 추가됨` 
-> `삭제됨`

## 반영 브랜치
fix/#27 -> develop
- #27 

## 스크린샷
수정 전
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/3407cb9a-49e1-40af-9b91-a5e77ec98594" width="200"/>

수정 후
<img src="https://github.com/aldalddl/GIPHY-Searcher-iOS/assets/47246760/49f5d277-9e4e-493a-81c5-7166e03717fd" width="200"/>