### PR TITLE
[Fix] GIF의 북마크가 삭제되지 않는 현상

### DIFF
--- a/GIPHYSearcher/Presentation/Main/MainViewController.swift
+++ b/GIPHYSearcher/Presentation/Main/MainViewController.swift
@@ -115,7 +115,7 @@ extension MainViewController {
         } else {
             sender.setImage(UIImage(systemName: "bookmark"), for: .normal)
             
-            if let filteredIndex = gifData.firstIndex(where: { $0.id == sender.customTag }) {
+            if let filteredIndex = self.bookmarkedData.firstIndex(where: { $0.id == sender.customTag }) {
                 self.bookmarkedData.remove(at: filteredIndex)
             }
             
@@ -138,8 +138,6 @@ extension MainViewController: GiphyAPIManagerDelegate {
         } else {
             gifData = data
         }
-
-        print(data)
         
         DispatchQueue.main.async {
             self.gifCollectionView.reloadData()


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 기능 구현 방식 변경
- [x] 버그 수정
- [ ] 그 외:

## 변경 내용
`index out of range` 에러 추가 수정

-> 삭제하려는 gif의 index를 찾는 데이터 변경 `gifData` -> `self.bookmarkedData`